### PR TITLE
kernel: netdev: add missing config for mlx5 driver (#4228)

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1079,12 +1079,15 @@ define KernelPackage/mlx4-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Mellanox ConnectX(R) mlx4 core Network Driver
   DEPENDS:=@PCI_SUPPORT +kmod-ptp
-  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_core.ko
+  FILES:= \
+	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_core.ko \
+	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko
   KCONFIG:= CONFIG_MLX4_EN \
+	CONFIG_MLX4_EN_DCB=n \
 	CONFIG_MLX4_CORE=y \
 	CONFIG_MLX4_CORE_GEN2=y \
 	CONFIG_MLX4_DEBUG=n
-  AUTOLOAD:=$(call AutoProbe,mlx4_core)
+  AUTOLOAD:=$(call AutoProbe,mlx4_core mlx4_en)
 endef
 
 define KernelPackage/mlx4-core/description
@@ -1100,7 +1103,20 @@ define KernelPackage/mlx5-core
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
   KCONFIG:= CONFIG_MLX5_CORE \
 	CONFIG_MLX5_CORE_EN=y \
-	CONFIG_MLX5_EN_RXNFC=y
+	CONFIG_MLX5_CORE_EN_DCB=n \
+	CONFIG_MLX5_CORE_IPOIB=n \
+	CONFIG_MLX5_EN_ARFS=n \
+	CONFIG_MLX5_EN_IPSEC=n \
+	CONFIG_MLX5_EN_RXNFC=y \
+	CONFIG_MLX5_EN_TLS=n \
+	CONFIG_MLX5_ESWITCH=n \
+	CONFIG_MLX5_FPGA=n \
+	CONFIG_MLX5_FPGA_IPSEC=n \
+	CONFIG_MLX5_FPGA_TLS=n \
+	CONFIG_MLX5_MPFS=y \
+	CONFIG_MLX5_SW_STEERING=n \
+	CONFIG_MLX5_TC_CT=n \
+	CONFIG_MLX5_TLS=n
   AUTOLOAD:=$(call AutoProbe,mlx5_core)
 endef
 


### PR DESCRIPTION
* kernel: Fix miss config and module for mlx driver

Missing config symbols could lead to build failures on kernel
4.14/4.19.

Signed-off-by: Tan Zien <nabsdh9@gmail.com>
[rephrase commit message - reorder symbols]
Signed-off-by: David Bauer <mail@david-bauer.net>

* kernel: netdev: add missing config for mlx5 driver

The mlk5 kmod lacks all necessary build symbols
for kernel 4.14 (again).

Add missing symbols to avoid build failure on these targets.

Signed-off-by: Tan Zien <nabsdh9@gmail.com>
[rewrite commit message - reorder symbols]
Signed-off-by: David Bauer <mail@david-bauer.net>

Co-authored-by: Tan Zien <nabsdh9@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
